### PR TITLE
Support multi users

### DIFF
--- a/smart/smart-one-info-small.js
+++ b/smart/smart-one-info-small.js
@@ -456,7 +456,7 @@ async function initialLogin() {
 async function saveCredentials(credentials) {
   const fm = FileManager.iCloud();
   const dir = fm.documentsDirectory();
-  const path = fm.joinPath(dir, 'smart-credentials.json');
+  const path = fm.joinPath(dir, 'smart-credentials-' + userName + '.json');
   fm.writeString(path, JSON.stringify(credentials));
 }
 
@@ -465,7 +465,7 @@ async function loadCachedCredentials() {
   // load existing credentials from iCloud Drive
   const fm = FileManager.iCloud();
   const dir = fm.documentsDirectory();
-  const path = fm.joinPath(dir, 'smart-credentials.json');
+  const path = fm.joinPath(dir, 'smart-credentials-' + userName + '.json');
   const credentials = Data.fromFile(path);
   if (credentials != null) {
     return JSON.parse(credentials.toRawString());


### PR DESCRIPTION
Suggestion to add support for using simultaneously more than one user.

It is made mandatory by the fact that the widget can work only with the latest car each user has accessed in the app.

If we want to look after 2 cars, we need 2 users.

## How I test it

This is the tests I made to confirm one user can only access one car at a time. Decided in Hello Smart. 

1. The widget works for Car A, I confirm it by going in scriptable and run it. 
2. I go to hello smart, which is showing Car A and I change to look at  Car B
3. I go back to scriptable and run the same script for Car A and it fails with following console logs

```
2023-11-18 14:09:09: Found apiAccessToken.
2023-11-18 14:09:09: Signing api request with hmac *********
2023-11-18 14:09:10: status code: 200
2023-11-18 14:09:10: {"data":null,"code":"8160","httpStatus":"OK","success":false,"hint":null,"sessionId":"***********","message":"Currently no permission to operate"}
```

4. I go back to hello smart and switch to car A
5. The widget works again perfectly 